### PR TITLE
[AARCH64] Add a flag to enable neon 64bit

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,8 @@ elif cpu_family == 'ppc' or cpu_family == 'ppc64'
   cdata.set('HAVE_POWERPC', true)
 elif cpu_family == 'arm'
   cdata.set('HAVE_ARM', true)
+elif cpu_family == 'aarch64'
+  cdata.set('HAVE_AARCH64', true)
 elif cpu_family == 'mips' and host_machine.endian() == 'little'
   cdata.set('HAVE_MIPSEL', true)
 else

--- a/orc/orcprogram-neon.c
+++ b/orc/orcprogram-neon.c
@@ -107,7 +107,7 @@ orc_neon_emit_epilogue (OrcCompiler *compiler)
 
 static OrcTarget neon_target = {
   "neon",
-#ifdef HAVE_ARM
+#if defined(HAVE_ARM) || defined(HAVE_AARCH64)
   TRUE,
 #else
   FALSE,
@@ -126,7 +126,7 @@ static OrcTarget neon_target = {
 void
 orc_neon_init (void)
 {
-#if defined(HAVE_ARM)
+#if defined(HAVE_ARM) || defined(HAVE_AARCH64)
   if (!(orc_arm_get_cpu_flags () & ORC_TARGET_NEON_NEON)) {
     ORC_INFO("marking neon backend non-executable");
     neon_target.executable = FALSE;
@@ -141,7 +141,14 @@ orc_neon_init (void)
 static unsigned int
 orc_compiler_neon_get_default_flags (void)
 {
-  return ORC_TARGET_NEON_NEON;
+  unsigned int flags = 0;
+
+#if defined(HAVE_AARCH64)
+  flags |= ORC_TARGET_NEON_64BIT;
+#endif
+  flags |= ORC_TARGET_NEON_NEON;
+
+  return flags;
 }
 
 static void
@@ -149,6 +156,12 @@ orc_compiler_neon_init (OrcCompiler *compiler)
 {
   int i;
   int loop_shift;
+
+  if (compiler->target_flags & ORC_TARGET_NEON_64BIT) {
+    compiler->is_64bit = TRUE;
+  }
+
+  /** @todo 64bit-specific register setting */
 
   for(i=ORC_GP_REG_BASE;i<ORC_GP_REG_BASE+16;i++){
     compiler->valid_regs[i] = 1;

--- a/orc/orctarget.h
+++ b/orc/orctarget.h
@@ -30,7 +30,8 @@ typedef enum {
 enum {
   ORC_TARGET_NEON_CLEAN_COMPILE = (1<<0),
   ORC_TARGET_NEON_NEON = (1<<1),
-  ORC_TARGET_NEON_EDSP = (1<<2)
+  ORC_TARGET_NEON_EDSP = (1<<2),
+  ORC_TARGET_NEON_64BIT = (1<<3)
 };
 
 enum {


### PR DESCRIPTION
This PR adds the flag to enable neon 64bit.
It's the first commit of ORC aarch64 support.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>