### PR TITLE
[BUILD] Add missing AArch64 flags for GBS build

### DIFF
--- a/orc/meson.build
+++ b/orc/meson.build
@@ -91,7 +91,7 @@ if cpu_family.startswith('x86')
   orc_sources += ['orccpu-x86.c']
 elif cpu_family == 'ppc' or cpu_family == 'ppc64'
   orc_sources += ['orccpu-powerpc.c']
-elif cpu_family == 'arm'
+elif cpu_family == 'arm' or cpu_family == 'aarch64'
   orc_sources += ['orccpu-arm.c']
 elif cpu_family == 'mips' and host_machine.endian() == 'little'
   orc_sources += ['orccpu-mips.c']

--- a/orc/orcarm.c
+++ b/orc/orcarm.c
@@ -14,7 +14,7 @@
 #include <orc/orcarm.h>
 #include <orc/orcutils.h>
 
-#ifdef HAVE_ARM
+#if defined(HAVE_ARM) || defined(HAVE_AARCH64)
 #if defined(__APPLE__)
 #include  <libkern/OSCacheControl.h>
 #endif
@@ -775,7 +775,7 @@ orc_arm_emit_rv (OrcCompiler *p, int op, OrcArmCond cond,
 void
 orc_arm_flush_cache (OrcCode *code)
 {
-#ifdef HAVE_ARM
+#if defined (HAVE_ARM) || defined (HAVE_AARCH64)
 #ifdef __APPLE__
   sys_dcache_flush(code->code, code->code_size);
   sys_icache_invalidate(code->exec, code->code_size);

--- a/orc/orccpu-arm.c
+++ b/orc/orccpu-arm.c
@@ -45,7 +45,7 @@
 
 /***** arm *****/
 
-#ifdef __arm__
+#if defined (__arm__) || defined (__aarch64__)
 #if 0
 static unsigned long
 orc_profile_stamp_xscale(void)

--- a/orc/orcutils.c
+++ b/orc/orcutils.c
@@ -45,7 +45,7 @@
  * @short_description: Orc utility functions
  */
 
-#if defined(__arm__) || defined(__mips__)
+#if defined(__arm__) || defined(__aarch64__) || defined(__mips__)
 char *
 get_proc_cpuinfo (void)
 {

--- a/orc/orcutils.h
+++ b/orc/orcutils.h
@@ -227,7 +227,7 @@ ORC_BEGIN_DECLS
 #ifdef ORC_ENABLE_UNSTABLE_API
 
 /* FIXME: remove, these are internal functions that were never exported */
-#if defined(__arm__) || defined(__mips__)
+#if defined(__arm__) || defined(__aarch64__) || defined(__mips__)
 char * get_proc_cpuinfo (void);
 #endif
 


### PR DESCRIPTION
This PR  adds missing AArch64 flags for GBS build.
                                                     
Signed-off-by: Dongju Chae <dongju.chae@samsung.com> 