### PR TITLE
[emit] Implement a 'ldr' emit function for AArch64

### DIFF
--- a/orc/orcarm.c
+++ b/orc/orcarm.c
@@ -64,6 +64,29 @@ orc_arm_reg_name (int reg)
   return gp_regs[reg&0xf];
 }
 
+const char *
+orc_arm64_reg_name (int reg, int reg_bits)
+{
+  static const char *gp_regs64[] = {
+     "x0",  "x1",  "x2",  "x3",  "x4",  "x5",  "x6",  "x7",  "x8",  "x9",
+    "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17", "x18", "x19",
+    "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28", "x29",
+    "x30",  "sp"
+  };
+  static const char *gp_regs32[] = {
+     "w0",  "w1",  "w2",  "w3",  "w4",  "w5",  "w6",  "w7",  "w8",  "w9",
+    "w10", "w11", "w12", "w13", "w14", "w15", "w16", "w17", "w18", "w19",
+    "w20", "w21", "w22", "w23", "w24", "w25", "w26", "w27", "w28", "w29",
+    "w30",  "sp"
+  };
+
+  if (reg < ORC_GP_REG_BASE || reg >= ORC_GP_REG_BASE+32) {
+    return "ERROR";
+  }
+
+  return reg_bits == 64 ? gp_regs64[reg&0x1f] : gp_regs32[reg&0x1f];
+}
+
 void
 orc_arm_emit (OrcCompiler *compiler, orc_uint32 insn)
 {

--- a/orc/orcarm.h
+++ b/orc/orcarm.h
@@ -126,6 +126,10 @@ ORC_API void orc_arm_emit_nop (OrcCompiler *compiler);
 
 ORC_API void orc_arm_flush_cache (OrcCode *code);
 
+/** AArch64 */
+ORC_API const char * orc_arm64_reg_name (int reg, int reg_bits);
+/** @todo add arm64-specific helper functions if needed */
+
 /* ALL cpus */
 /* data procesing instructions */
 /* <op>{<cond>}{s} {<Rd>}, <Rn>, #imm */


### PR DESCRIPTION
This PR implements a 'ldr' emit function for AArch64. The unsigned offset variant of LDR (immediate) is encoded to reuse the same wrapper for ARM32.

It also adds a helper function to obtain AArch64 register names from enum.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>