### PR TITLE
[emit] Implement emit functions for arithmetic ops with three variants

### DIFF
--- a/orc/orcarm.c
+++ b/orc/orcarm.c
@@ -65,7 +65,7 @@ orc_arm_reg_name (int reg)
 }
 
 const char *
-orc_arm64_reg_name (int reg, int reg_bits)
+orc_arm64_reg_name (int reg, OrcArm64RegBits bits)
 {
   static const char *gp_regs64[] = {
      "x0",  "x1",  "x2",  "x3",  "x4",  "x5",  "x6",  "x7",  "x8",  "x9",
@@ -84,7 +84,7 @@ orc_arm64_reg_name (int reg, int reg_bits)
     return "ERROR";
   }
 
-  return reg_bits == 64 ? gp_regs64[reg&0x1f] : gp_regs32[reg&0x1f];
+  return bits == ORC_ARM64_REG_64 ? gp_regs64[reg&0x1f] : gp_regs32[reg&0x1f];
 }
 
 void
@@ -430,9 +430,11 @@ orc_arm_emit_load_reg (OrcCompiler *compiler, int dest, int src1, int offset)
     code |= (src1&0x1f) << 5;
     code |= (dest&0x1f);
 
+    /** @todo change this function to support both register bits */
+
     ORC_ASM_CODE(compiler,"  ldr %s, [%s, #%d]\n",
-        orc_arm64_reg_name (dest,64),
-        orc_arm64_reg_name (src1,64), offset);
+        orc_arm64_reg_name (dest,ORC_ARM64_REG_64),
+        orc_arm64_reg_name (src1,ORC_ARM64_REG_64), offset);
   } else {
     code = 0xe5900000;
     code |= (src1&0xf) << 16;

--- a/orc/orcarm.h
+++ b/orc/orcarm.h
@@ -87,6 +87,31 @@ typedef enum {
 } OrcArmDP;
 
 typedef enum {
+  /** arithmetic */
+  ORC_ARM64_DP_ADD = 0,
+  ORC_ARM64_DP_CMN, /** alias of ADDS */
+  ORC_ARM64_DP_SUB,
+  ORC_ARM64_DP_CMP /** alias of SUBS */
+} OrcArm64DP;
+
+typedef enum {
+  ORC_ARM64_TYPE_IMM = 0,
+  ORC_ARM64_TYPE_REG,
+  ORC_ARM64_TYPE_EXT
+} OrcArm64Type;
+
+typedef enum {
+  ORC_ARM64_EXTEND_UXTB,
+  ORC_ARM64_EXTEND_UXTH,
+  ORC_ARM64_EXTEND_UXTW,
+  ORC_ARM64_EXTEND_UXTX,
+  ORC_ARM64_EXTEND_SXTB,
+  ORC_ARM64_EXTEND_SXTH,
+  ORC_ARM64_EXTEND_SXTW,
+  ORC_ARM64_EXTEND_SXTX,
+} OrcArm64Extend;
+
+typedef enum {
   ORC_ARM_COND_EQ = 0,
   ORC_ARM_COND_NE,
   ORC_ARM_COND_CS,
@@ -364,6 +389,8 @@ ORC_API void orc_arm_flush_cache (OrcCode *code);
 /** AArch64 */
 
 ORC_API const char * orc_arm64_reg_name (int reg, OrcArm64RegBits bits);
+ORC_API void orc_arm64_emit_am (OrcCompiler *p, OrcArm64RegBits bits, OrcArm64DP opcode,
+    OrcArm64Type type, int opt, int Rd, int Rn, int Rm, orc_uint64 val);
 /** @todo add arm64-specific helper functions if needed */
 
 #endif

--- a/orc/orcarm.h
+++ b/orc/orcarm.h
@@ -63,6 +63,11 @@ typedef enum {
 } OrcArm64Register;
 
 typedef enum {
+  ORC_ARM64_REG_32 = 32,
+  ORC_ARM64_REG_64 = 64
+} OrcArm64RegBits;
+
+typedef enum {
   ORC_ARM_DP_AND = 0,
   ORC_ARM_DP_EOR,
   ORC_ARM_DP_SUB,
@@ -160,10 +165,6 @@ ORC_API void orc_arm_emit_rv (OrcCompiler *p, int op, OrcArmCond cond,
 ORC_API void orc_arm_emit_nop (OrcCompiler *compiler);
 
 ORC_API void orc_arm_flush_cache (OrcCode *code);
-
-/** AArch64 */
-ORC_API const char * orc_arm64_reg_name (int reg, int reg_bits);
-/** @todo add arm64-specific helper functions if needed */
 
 /* ALL cpus */
 /* data procesing instructions */
@@ -359,6 +360,11 @@ ORC_API const char * orc_arm64_reg_name (int reg, int reg_bits);
 /* reversing */
 #define orc_arm_emit_rev(p,cond,Rd,Rm)                orc_arm_emit_rv (p,0,cond,Rd,Rm)
 #define orc_arm_emit_rev16(p,cond,Rd,Rm)              orc_arm_emit_rv (p,1,cond,Rd,Rm)
+
+/** AArch64 */
+
+ORC_API const char * orc_arm64_reg_name (int reg, OrcArm64RegBits bits);
+/** @todo add arm64-specific helper functions if needed */
 
 #endif
 


### PR DESCRIPTION
This PR implements emit functions for arithmetic ops with three variants
- immediate, shifted register, extended register.

So, the supported instructions are
- add, cmn (alias of adds), sub, cmp (alias of subs)

They will be supported by various macros using this emit function.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

