### PR TITLE
[emit] Add AArch64 support to NOP emit implementation

### DIFF
--- a/orc/orcarm.c
+++ b/orc/orcarm.c
@@ -286,7 +286,10 @@ void
 orc_arm_emit_nop (OrcCompiler *compiler)
 {
   ORC_ASM_CODE(compiler,"  nop\n");
-  orc_arm_emit (compiler, 0xe1a00000);
+  if (compiler->is_64bit)
+    orc_arm_emit (compiler, 0xd503201f);
+  else
+    orc_arm_emit (compiler, 0xe1a00000);
 }
 
 void


### PR DESCRIPTION
This PR adds AArch64 support to NOP emit implementation codes.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>