### PR TITLE
[emit] implement emit function for ret op

### DIFF
--- a/orc/orcarm.c
+++ b/orc/orcarm.c
@@ -97,8 +97,12 @@ orc_arm_emit (OrcCompiler *compiler, orc_uint32 insn)
 void
 orc_arm_emit_bx_lr (OrcCompiler *compiler)
 {
-  ORC_ASM_CODE(compiler,"  bx lr\n");
-  orc_arm_emit (compiler, 0xe12fff1e);
+  if (compiler->is_64bit) {
+    orc_arm64_emit_ret (compiler, ORC_ARM64_LR);
+  } else {
+    ORC_ASM_CODE(compiler,"  bx lr\n");
+    orc_arm_emit (compiler, 0xe12fff1e);
+  }
 }
 
 void
@@ -1645,6 +1649,21 @@ orc_arm64_emit_mem (OrcCompiler *p, OrcArm64RegBits bits, OrcArm64Mem opcode,
       insn_names[opcode],
       orc_arm64_reg_name(Rt, bits),
       opt_rn, opt_rm);
+
+  orc_arm_emit (p, code);
+}
+
+/** Return from subroutine */
+
+void
+orc_arm64_emit_ret (OrcCompiler *p, int Rn)
+{
+  orc_uint32 code;
+
+  code = 0xd65f0000 | ((Rn & 0x1f) << 5);
+
+  ORC_ASM_CODE (p, "  ret %s\n",
+      Rn == ORC_ARM64_LR ? "" : orc_arm64_reg_name (Rn, ORC_ARM64_REG_64));
 
   orc_arm_emit (p, code);
 }

--- a/orc/orcarm.h
+++ b/orc/orcarm.h
@@ -415,6 +415,7 @@ ORC_API void orc_arm64_emit_extr (OrcCompiler *p, OrcArm64RegBits bits,
     int Rd, int Rn, int Rm, orc_uint32 imm);
 ORC_API void orc_arm64_emit_mem (OrcCompiler *p, OrcArm64RegBits bits, OrcArm64Mem opcode,
     OrcArm64Type type, int opt, int Rt, int Rn, int Rm, orc_uint64 val);
+ORC_API void orc_arm64_emit_ret (OrcCompiler *p, int Rn);
 /** @todo add arm64-specific helper functions if needed */
 
 /** Data Procesing (DP) instructions */


### PR DESCRIPTION
This PR implements emit function for ret op.

Note that, in AArch64, PC is not accessible register anymore.
So, "MOV PC, LR", "POP {PC}", "BX LR" are not available.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>