### PR TITLE
[Fix] Minor fix in function definition of orc_arm64_emit_sft()

### DIFF
--- a/orc/orcarm.h
+++ b/orc/orcarm.h
@@ -415,7 +415,7 @@ ORC_API void orc_arm64_emit_am (OrcCompiler *p, OrcArm64RegBits bits, OrcArm64DP
 ORC_API void orc_arm64_emit_lg (OrcCompiler *p, OrcArm64RegBits bits, OrcArm64DP opcode,
     OrcArm64Type type, int opt, int Rd, int Rn, int Rm, orc_uint64 val);
 ORC_API void orc_arm64_emit_sft (OrcCompiler *p, OrcArm64RegBits bits, OrcArmShift shift,
-    int Rd, int Rn, int Rm, orc_uint64 val);
+    int Rd, int Rn, int Rm);
 ORC_API void orc_arm64_emit_bfm (OrcCompiler *p, OrcArm64RegBits bits, OrcArm64DP opcode,
     int Rd, int Rn, orc_uint32 immr, orc_uint32 imms);
 ORC_API void orc_arm64_emit_extr (OrcCompiler *p, OrcArm64RegBits bits,


### PR DESCRIPTION
This PR fixes wrong function definition of orc_arm64_emit_sft()

I think we need TAOS-CI for this repository too.
Even if I perform build tests before submitting PRs, there are some mistakes :(

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>