### PR TITLE
[BUG] Fix wrong encoding in bitfield move ops

### DIFF
--- a/orc/orcarm.c
+++ b/orc/orcarm.c
@@ -1351,7 +1351,7 @@ orc_arm64_emit_sft (OrcCompiler *p, OrcArm64RegBits bits, OrcArmShift shift,
  * Note that Bitfiled Move is usually accessed via one of its aliases
  */
 
-#define arm64_code_bfm(b,opcode,immr,imms,Rn,Rd) (0x19000000 | ((((b)==64)&0x1)<<31) | \
+#define arm64_code_bfm(b,opcode,immr,imms,Rn,Rd) (0x13000000 | ((((b)==64)&0x1)<<31) | \
     (((opcode)&0x3)<<29) | ((((b)==64)&0x1)<<22) | (((immr)&0x3f)<<16) | (((imms)&0x3f)<<10) | \
     (((Rn)&0x1f)<<5) | ((Rd)&0x1f))
 

--- a/orc/orcarm.h
+++ b/orc/orcarm.h
@@ -775,7 +775,7 @@ ORC_API void orc_arm64_emit_ret (OrcCompiler *p, int Rn);
 #define orc_arm64_emit_lsr_imm(p,bits,Rd,Rn,imm) \
   orc_arm64_emit_bfm(p,bits,ORC_ARM64_DP_UBFM,Rd,Rn,imm,0x1f)
 #define orc_arm64_emit_asr_imm(p,bits,Rd,Rn,imm) \
-  orc_arm64_emit_bfm(p,bits,ORC_ARM64_DP_ORC_ARM64_DP_SBFM,Rd,Rn,imm,0x1f)
+  orc_arm64_emit_bfm(p,bits,ORC_ARM64_DP_SBFM,Rd,Rn,imm,0x1f)
 #define orc_arm64_emit_ror_imm(p,bits,Rd,Rn,imm) \
   orc_arm64_emit_extr(p,bits,Rd,Rn,Rn,imm)
 /** ORC_ARM64_TYPE_REG */


### PR DESCRIPTION
This PR fixes the wrong encoding in bitfield move ops.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>